### PR TITLE
Corrige mensagens 1:1 vinculadas a contato de grupo legado no Chatwoot

### DIFF
--- a/cmd/server/chatwoot.go
+++ b/cmd/server/chatwoot.go
@@ -29,6 +29,10 @@ import (
 
 const cwChatIDAttr = "wacalls_chat_id"
 
+func isGroupChatID(id string) bool {
+	return strings.HasSuffix(id, "@g.us")
+}
+
 type ChatwootConfig struct {
 	URL             string `json:"url"`
 	AccountID       int    `json:"account_id"`
@@ -104,6 +108,9 @@ func (s *Session) chatwootPushIncoming(evt *events.Message) {
 		}
 	}
 	chatID := phone + "@" + types.DefaultUserServer
+	if isGroupChatID(chat.String()) {
+		chatID = chat.String()
+	}
 	name := evt.Info.PushName
 	if name == "" {
 		name = phone
@@ -150,16 +157,28 @@ var avatarSynced sync.Map
 
 // ensureContact acha (por telefone) ou cria o contato e garante o source_id da inbox.
 func (c ChatwootConfig) ensureContact(chatID, phone, name, avatarURL string) (contactID int, sourceID string, err error) {
-	// procura por telefone
 	if res, code, e := c.req(http.MethodGet, "/contacts/search?q="+phone, nil); e == nil && code == 200 {
 		for _, it := range asList(res["payload"]) {
 			m := asMap(it)
 			if id := asInt(m["id"]); id != 0 {
+				ident := asStr(m["identifier"])
+				attr := ""
+				if ca := asMap(m["custom_attributes"]); ca != nil {
+					attr = asStr(ca[cwChatIDAttr])
+				}
+				if isGroupChatID(ident) && ident != chatID {
+					continue
+				}
+				if isGroupChatID(attr) && attr != chatID {
+					continue
+				}
+				if isGroupChatID(chatID) && ident != chatID && attr != chatID {
+					continue
+				}
 				c.syncAvatar(id, avatarURL)
 				if sid := sourceIDForInbox(m, c.InboxID); sid != "" {
 					return id, sid, nil
 				}
-				// achou contato mas sem source_id p/ esta inbox -> cria contact_inbox
 				sid, e2 := c.ensureContactInbox(id)
 				return id, sid, e2
 			}
@@ -496,11 +515,11 @@ func chatIDFromWebhook(body map[string]any) string {
 			return v
 		}
 	}
-	if ph := asStr(sender["phone_number"]); ph != "" {
-		return strings.TrimPrefix(ph, "+")
-	}
 	if id := asStr(sender["identifier"]); id != "" {
 		return id
+	}
+	if ph := asStr(sender["phone_number"]); ph != "" {
+		return strings.TrimPrefix(ph, "+")
 	}
 	return ""
 }
@@ -541,11 +560,9 @@ func (s *server) handleChatwootResolve(w http.ResponseWriter, r *http.Request) {
 	phone := ""
 	if ca := asMap(sender["custom_attributes"]); ca != nil {
 		raw := asStr(ca[cwChatIDAttr])
-		if raw != "" {
+		if raw != "" && !isGroupChatID(raw) {
 			if jid, e := types.ParseJID(raw); e == nil {
-				phone = sess.realPhone(jid) // converte LID->PN se necessário
-			} else {
-				phone = digitsOnly(raw)
+				phone = sess.realPhone(jid)
 			}
 		}
 	}

--- a/cmd/server/chatwoot_test.go
+++ b/cmd/server/chatwoot_test.go
@@ -1,0 +1,25 @@
+package main
+
+import "testing"
+
+func TestIsGroupChatID(t *testing.T) {
+	if !isGroupChatID("5511999999999-1531238647@g.us") {
+		t.Fatal("expected group JID")
+	}
+	if isGroupChatID("5511999999999@s.whatsapp.net") {
+		t.Fatal("expected individual JID")
+	}
+}
+
+func TestEnsureContactSkipsWrongGroup(t *testing.T) {
+	groupLegacy := map[string]any{"identifier": "5511999999999-1531238647@g.us"}
+	chat1to1 := "5511999999999@s.whatsapp.net"
+	ident := asStr(groupLegacy["identifier"])
+	if !(isGroupChatID(ident) && ident != chat1to1) {
+		t.Fatal("1:1 must skip legacy group on search")
+	}
+	groupChat := "5511999999999-1531238647@g.us"
+	if isGroupChatID(ident) && ident != groupChat {
+		t.Fatal("group message must not skip matching group contact")
+	}
+}


### PR DESCRIPTION
## Summary
- Ignora contatos `@g.us` na busca por telefone quando não correspondem ao `chatID` da mensagem recebida
- Evita reutilizar grupos legados no formato `{phone}-{timestamp}@g.us` em conversas 1:1

Fixes #8

## Test plan
- [ ] Enviar mensagem 1:1 com contato de grupo legado no Chatwoot
- [ ] Confirmar que a conversa vai para o contato individual
- [ ] Responder pelo Chatwoot e validar entrega no 1:1

Made with [Cursor](https://cursor.com)