### PR TITLE
fix(recording): gravação picotada — emenda frames por cursor de lado (jitter buffer) em vez do relógio de chegada

### DIFF
--- a/cmd/server/recorder.go
+++ b/cmd/server/recorder.go
@@ -28,6 +28,12 @@ const (
 	recChanCap = 512
 	// Chamadas muito curtas não têm conteúdo útil — não geram arquivo.
 	recMinSeconds = 3
+	// Limiar de ressincronização do posicionamento na timeline: dentro dele,
+	// frames de um mesmo lado são emendados em sequência (jitter de rede não
+	// vira buraco nem sobreposição); acima dele o lado reancora no relógio de
+	// chegada (silêncio real: mute, DTX, perda prolongada ou navegador que só
+	// conecta depois do início da chamada).
+	recResyncSamples = recSampleRate * 3 / 10 // 300 ms
 )
 
 // recordingDir é onde os MP3s finalizados ficam até serem baixados/enviados.
@@ -59,6 +65,17 @@ type callRecorder struct {
 
 	frames chan recFrame
 	mixed  []float32
+
+	// Posicionamento na timeline (só a goroutine de mixagem toca nisso): cada
+	// lado tem um cursor de amostras que avança com o próprio áudio, então o
+	// stream é emendado contínuo e o jitter de chegada não abre buracos nem
+	// sobrepõe frames do mesmo lado. O offset desconta o setup/toque anterior
+	// ao primeiro frame gravado — a duração do MP3 passa a bater com a da
+	// conversa de fato.
+	cursors   [2]int
+	cursorSet [2]bool
+	offset    int
+	offsetSet bool
 
 	// sendMu protege frames contra "send em canal fechado": writes tomam RLock
 	// (concorrentes), o fechamento toma Lock (exclusivo) e marca closed.
@@ -125,16 +142,49 @@ func (r *callRecorder) closeFrames() {
 func (r *callRecorder) mixLoop() {
 	defer close(r.doneMix)
 	for frame := range r.frames {
-		r.mixed = mixFrameInto(r.mixed, frame.at, frame.pcm)
+		r.place(frame)
 	}
 }
 
-// mixFrameInto posiciona um frame na timeline pela sua marca de chegada e o soma
-// (com clamp) ao buffer, crescendo-o conforme necessário.
-func mixFrameInto(buf []float32, at time.Duration, pcm []float32) []float32 {
+// place decide ONDE o frame entra na timeline. O relógio de chegada só ancora o
+// primeiro frame de cada lado e os casos em que a deriva do cursor passa do
+// limiar (silêncio real); no regime normal cada lado é um stream contínuo e os
+// frames são emendados em sequência — o mesmo papel do jitter buffer que o
+// navegador e o WhatsApp usam na reprodução ao vivo. Posicionar pelo relógio de
+// chegada (comportamento anterior) fazia frame atrasado virar buraco de zeros e
+// rajada pós-jitter virar soma sobreposta (distorção/clipping) na gravação.
+func (r *callRecorder) place(f recFrame) {
 	// O instante de chegada cobre o FIM do frame, então recuamos len(pcm)
 	// amostras para achar onde ele começa.
-	startIdx := int(at.Seconds()*float64(recSampleRate)) - len(pcm)
+	wall := int(f.at.Seconds()*float64(recSampleRate)) - len(f.pcm)
+	if wall < 0 {
+		wall = 0
+	}
+	side := int(f.side)
+	idx := r.cursors[side]
+	drift := wall - idx
+	if !r.cursorSet[side] || drift > recResyncSamples || drift < -recResyncSamples {
+		idx = wall
+		r.cursorSet[side] = true
+	}
+	r.cursors[side] = idx + len(f.pcm)
+	if !r.offsetSet {
+		// O primeiro frame gravado define o zero da timeline: o toque/setup
+		// antes de haver áudio não entra como silêncio no arquivo.
+		r.offset = idx
+		r.offsetSet = true
+	}
+	rel := idx - r.offset
+	if rel < 0 {
+		rel = 0 // âncora anterior ao zero (jitter na largada): cola no início
+	}
+	r.mixed = mixFrameInto(r.mixed, rel, f.pcm)
+}
+
+// mixFrameInto soma o frame (com clamp) ao buffer na posição dada, crescendo-o
+// conforme necessário. A soma existe para mixar os DOIS lados numa trilha mono;
+// sobreposição do mesmo lado não acontece mais (cursor sequencial em place).
+func mixFrameInto(buf []float32, startIdx int, pcm []float32) []float32 {
 	if startIdx < 0 {
 		startIdx = 0
 	}

--- a/cmd/server/recorder_test.go
+++ b/cmd/server/recorder_test.go
@@ -8,10 +8,10 @@ import (
 	"time"
 )
 
-func TestMixFrameInto_PositionsByArrivalTime(t *testing.T) {
-	// Um frame que chega em 1s, com 320 amostras (20 ms @ 16k), deve começar em
-	// 16000 - 320 = 15680.
-	buf := mixFrameInto(nil, time.Second, make([]float32, 320))
+func TestMixFrameInto_PositionsByIndex(t *testing.T) {
+	// Um frame de 320 amostras (20 ms @ 16k) posicionado em 15680 deve deixar
+	// silêncio antes e terminar o buffer em 16000.
+	buf := mixFrameInto(nil, 15680, make([]float32, 320))
 	if len(buf) != 16000 {
 		t.Fatalf("expected buffer len 16000, got %d", len(buf))
 	}
@@ -23,9 +23,8 @@ func TestMixFrameInto_PositionsByArrivalTime(t *testing.T) {
 func TestMixFrameInto_SumsOverlappingSides(t *testing.T) {
 	a := []float32{0.5, 0.5, 0.5}
 	b := []float32{0.25, 0.25, 0.25}
-	at := time.Duration(len(a)) * time.Second / recSampleRate
-	buf := mixFrameInto(nil, at, a)
-	buf = mixFrameInto(buf, at, b)
+	buf := mixFrameInto(nil, 0, a)
+	buf = mixFrameInto(buf, 0, b)
 	for i := 0; i < 3; i++ {
 		if math.Abs(float64(buf[i]-0.75)) > 1e-6 {
 			t.Fatalf("expected mixed 0.75 at %d, got %f", i, buf[i])
@@ -34,14 +33,88 @@ func TestMixFrameInto_SumsOverlappingSides(t *testing.T) {
 }
 
 func TestMixFrameInto_ClampsToRange(t *testing.T) {
-	at := time.Duration(2) * time.Second / recSampleRate
-	buf := mixFrameInto(nil, at, []float32{0.8, -0.8})
-	buf = mixFrameInto(buf, at, []float32{0.8, -0.8})
-	if buf[0] != 1 {
-		t.Fatalf("expected clamp to +1, got %f", buf[0])
+	buf := mixFrameInto(nil, 2, []float32{0.8, -0.8})
+	buf = mixFrameInto(buf, 2, []float32{0.8, -0.8})
+	if buf[2] != 1 {
+		t.Fatalf("expected clamp to +1, got %f", buf[2])
 	}
-	if buf[1] != -1 {
-		t.Fatalf("expected clamp to -1, got %f", buf[1])
+	if buf[3] != -1 {
+		t.Fatalf("expected clamp to -1, got %f", buf[3])
+	}
+}
+
+// frame20ms devolve um frame de 20 ms @ 16k preenchido com o valor dado.
+func frame20ms(v float32) []float32 {
+	pcm := make([]float32, 320)
+	for i := range pcm {
+		pcm[i] = v
+	}
+	return pcm
+}
+
+func TestPlace_JitterDoesNotCreateGapsNorOverlap(t *testing.T) {
+	// Cinco frames contíguos do mesmo lado chegando com jitter (fora da grade
+	// de 20 ms) devem sair emendados: sem zeros entre eles e sem soma
+	// sobreposta — exatamente 5×320 amostras com o valor original.
+	r := &callRecorder{}
+	for _, at := range []time.Duration{
+		20 * time.Millisecond,
+		55 * time.Millisecond, // atrasado 15 ms
+		61 * time.Millisecond, // rajada logo atrás
+		95 * time.Millisecond,
+		130 * time.Millisecond,
+	} {
+		r.place(recFrame{side: sidePeer, at: at, pcm: frame20ms(0.5)})
+	}
+	if len(r.mixed) != 5*320 {
+		t.Fatalf("expected %d samples, got %d", 5*320, len(r.mixed))
+	}
+	for i, s := range r.mixed {
+		if math.Abs(float64(s-0.5)) > 1e-6 {
+			t.Fatalf("expected seamless 0.5 at %d, got %f (gap or overlap)", i, s)
+		}
+	}
+}
+
+func TestPlace_ResyncKeepsRealSilence(t *testing.T) {
+	// Um vão real (mute/perda prolongada) acima do limiar deve reancorar no
+	// relógio: o silêncio permanece na gravação.
+	r := &callRecorder{}
+	r.place(recFrame{side: sidePeer, at: 20 * time.Millisecond, pcm: frame20ms(0.5)})
+	r.place(recFrame{side: sidePeer, at: 2 * time.Second, pcm: frame20ms(0.5)})
+	wantLen := 2 * recSampleRate // reancorado: termina no instante de chegada
+	if len(r.mixed) != wantLen {
+		t.Fatalf("expected %d samples, got %d", wantLen, len(r.mixed))
+	}
+	if r.mixed[len(r.mixed)/2] != 0 {
+		t.Fatal("expected silence preserved inside the real gap")
+	}
+}
+
+func TestPlace_TrimsLeadingSetupSilence(t *testing.T) {
+	// O toque/setup antes do primeiro frame não deve virar silêncio no arquivo.
+	r := &callRecorder{}
+	r.place(recFrame{side: sidePeer, at: 11 * time.Second, pcm: frame20ms(0.5)})
+	if len(r.mixed) != 320 {
+		t.Fatalf("expected 320 samples (no leading silence), got %d", len(r.mixed))
+	}
+}
+
+func TestPlace_SidesStayAligned(t *testing.T) {
+	// O navegador conecta 0.5s depois do peer: a defasagem relativa entre os
+	// lados precisa sobreviver ao corte do silêncio inicial.
+	r := &callRecorder{}
+	r.place(recFrame{side: sidePeer, at: time.Second, pcm: frame20ms(0.5)})
+	r.place(recFrame{side: sideBrowser, at: 1500 * time.Millisecond, pcm: frame20ms(0.25)})
+	wantLen := 8000 + 320 // browser em +0.5s relativos
+	if len(r.mixed) != wantLen {
+		t.Fatalf("expected %d samples, got %d", wantLen, len(r.mixed))
+	}
+	if math.Abs(float64(r.mixed[0]-0.5)) > 1e-6 {
+		t.Fatalf("expected peer at t=0, got %f", r.mixed[0])
+	}
+	if math.Abs(float64(r.mixed[8000]-0.25)) > 1e-6 {
+		t.Fatalf("expected browser at +0.5s, got %f", r.mixed[8000])
 	}
 }
 


### PR DESCRIPTION
Fixes #16

## O que este PR faz

Corrige a gravação picotada: o mixer deixava de posicionar frames pelo **instante de chegada** e passa a emendar cada lado como **stream contínuo** (cursor de amostras por lado), reancorando no relógio só quando a deriva passa de 300 ms (silêncio real: mute, DTX, perda prolongada, navegador conectando depois do início).

O diagnóstico completo, com medições de MP3s reais de produção (68 trechos de silêncio digital a −60 dB numa chamada de 45 s, pico a −0,07 dB), está no issue #16. Em resumo: com o alinhamento por chegada, frame atrasado virava buraco de zeros e rajada pós-jitter virava soma sobreposta (clamp ±1 → distorção). Ao vivo não se nota porque navegador e WhatsApp têm jitter buffer de reprodução — o recorder era o único consumidor sem um.

## Como

Toda a mudança fica em `cmd/server/recorder.go`, na goroutine única de mixagem (sem lock novo, sem mudança no hot path):

- `place()` (novo): decide onde o frame entra. Regime normal = `cursor` do lado avança `len(pcm)` por frame, emendando o stream. Reancora pelo relógio de chegada apenas no primeiro frame do lado ou quando `|deriva| > 300 ms`.
- `mixFrameInto()` passa a receber o índice pronto; a soma com clamp continua existindo **só** para mixar os dois lados em mono — sobreposição do mesmo lado não acontece mais por construção.
- O zero da timeline agora é o primeiro frame gravado: o toque/setup não entra mais como silêncio no início e a **duração do MP3 passa a bater com a da conversa** (antes: arquivo de 56 s para chamada de 45 s).

Sem mudança de API: `writePeer`/`writeBrowser`, o encode MP3 e a entrega (Chatwoot/webhook) seguem idênticos.

## Testes

- Novos: jitter não abre buraco nem sobrepõe (5 frames com chegadas irregulares → saída contígua exata), vão real acima do limiar preserva o silêncio, corte do silêncio inicial, defasagem entre lados sobrevive ao corte.
- Ajustados à nova assinatura: posicionamento por índice, soma dos dois lados, clamp.
- `go build` + `go vet` + `go test ./... -race` verdes (Go 1.26.4).

## Como validar na prática

Ligar com a rede "ruim" de verdade (agente em Wi-Fi/4G) e comparar a gravação antes/depois — antes: `ffmpeg -i gravacao.mp3 -af silencedetect=noise=-60dB:d=0.04 -f null -` mostra dezenas de silêncios digitais no meio da fala; depois devem restar apenas as pausas naturais (que não caem a −60 dB).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
